### PR TITLE
Generate tests per method

### DIFF
--- a/src/Commands/CreateUnitTestBoilerplateCommand.cs
+++ b/src/Commands/CreateUnitTestBoilerplateCommand.cs
@@ -91,7 +91,8 @@ namespace UnitTestBoilerplate.Commands
 				var menuItem = new OleMenuCommand(this.MenuItemCallback, menuCommandId);
 				menuItem.BeforeQueryStatus += (sender, args) =>
 				{
-					menuItem.Visible = SolutionUtilities.GetSelectedFiles(dte).Any(file => file != null && file.FilePath != null && file.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase));
+					menuItem.Visible = SolutionUtilities.GetSelectedFiles(dte).Any(file => file != null && file.FilePath != null && file.FilePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+						|| SolutionUtilities.GetSelectedFunction(dte) != null;
 				};
 
 				commandService.AddCommand(menuItem);

--- a/src/CreateUnitTestBoilerplateCommandPackage_Debug.vsct
+++ b/src/CreateUnitTestBoilerplateCommandPackage_Debug.vsct
@@ -53,6 +53,9 @@
       <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="DebugMenuGroup" priority="0x0600">
         <Parent guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="DebugTopLevelMenu" />
       </Group>
+      <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
+          <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+      </Group>
     </Groups>
 
     <!--Buttons section. -->

--- a/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
+++ b/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
@@ -14,10 +14,10 @@
         in C++ files. Using this ability of the compiler here, we include some files
         defining some of the constants that we will use inside the file. -->
 
-  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio.--> 
+  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
   <Extern href="stdidcmd.h"/>
 
-  <!--This header contains the command ids for the menus provided by the shell.--> 
+  <!--This header contains the command ids for the menus provided by the shell. -->
   <Extern href="vsshlids.h"/>
 
   <!--The Commands section is where commands, menus, and menu groups are defined.

--- a/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
+++ b/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
@@ -14,11 +14,11 @@
         in C++ files. Using this ability of the compiler here, we include some files
         defining some of the constants that we will use inside the file. -->
 
-  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
+  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. --><!--
   <Extern href="stdidcmd.h"/>
 
-  <!--This header contains the command ids for the menus provided by the shell. -->
-  <Extern href="vsshlids.h"/>
+  --><!--This header contains the command ids for the menus provided by the shell. --><!--
+  <Extern href="vsshlids.h"/>-->
 
   <!--The Commands section is where commands, menus, and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
@@ -38,6 +38,12 @@
     <Groups>
       <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+      </Group>
+      <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
+          <Parent guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="DebugTopLevelMenu" />
+      </Group>
+      <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
+          <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
       </Group>
     </Groups>
 

--- a/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
+++ b/src/CreateUnitTestBoilerplateCommandPackage_Release.vsct
@@ -14,11 +14,11 @@
         in C++ files. Using this ability of the compiler here, we include some files
         defining some of the constants that we will use inside the file. -->
 
-  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. --><!--
+  <!--This is the file that defines the IDs for all the commands exposed by VisualStudio.--> 
   <Extern href="stdidcmd.h"/>
 
-  --><!--This header contains the command ids for the menus provided by the shell. --><!--
-  <Extern href="vsshlids.h"/>-->
+  <!--This header contains the command ids for the menus provided by the shell.--> 
+  <Extern href="vsshlids.h"/>
 
   <!--The Commands section is where commands, menus, and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
@@ -38,12 +38,6 @@
     <Groups>
       <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
-      </Group>
-      <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
-          <Parent guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="DebugTopLevelMenu" />
-      </Group>
-      <Group guid="guidCreateUnitTestBoilerplateCommandPackageCmdSet" id="MyMenuGroup" priority="0x0600">
-          <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
       </Group>
     </Groups>
 

--- a/src/Model/TestFileContext.cs
+++ b/src/Model/TestFileContext.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace UnitTestBoilerplate.Model
+{
+	/// <summary>
+	/// Holds all the data required to generate the test file. Includes information about the class to generate tests for, and the unit test project the test will be added to.
+	/// </summary>
+	public class TestFileContext
+	{
+		public TestFileContext(
+			Document document,
+			string className,
+			string classNamespace,
+			IList<MethodDeclarationSyntax> methodDeclarations,
+			IList<string> usingNamespaces)
+		{
+			this.Document = document;
+			this.ClassName = className;
+			this.ClassNamespace = classNamespace;
+			this.MethodDeclarations = methodDeclarations;
+			this.UsingNamespaces = usingNamespaces;
+		}
+
+		public Document Document { get; }
+
+
+		public string ClassName { get; }
+
+		public string ClassNamespace { get; }
+
+		public IList<MethodDeclarationSyntax> MethodDeclarations { get; }
+
+		public IList<string> UsedTestMethodNames { get; } = new List<string>();
+
+		public IList<string> UsingNamespaces { get; } = new List<string>();
+	}
+}

--- a/src/Services/ITestGenerationService.cs
+++ b/src/Services/ITestGenerationService.cs
@@ -9,14 +9,16 @@ namespace UnitTestBoilerplate.Services
 			ProjectItemSummary selectedFile,
 			EnvDTE.Project targetProject, 
 			TestFramework testFramework,
-			MockFramework mockFramework);
+			MockFramework mockFramework,
+			EnvDTE80.CodeFunction2 selectedFunction = null);
 
 		Task GenerateUnitTestFileAsync(
 			ProjectItemSummary selectedFile,
 			string targetFilePath,
 			string targetProjectNamespace,
 			TestFramework testFramework,
-			MockFramework mockFramework);
+			MockFramework mockFramework,
+			EnvDTE80.CodeFunction2 selectedFunction = null);
 
 		string GetRelativePath(ProjectItemSummary selectedFile);
 	}

--- a/src/UnitTestBoilerplate.csproj
+++ b/src/UnitTestBoilerplate.csproj
@@ -51,7 +51,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTestBoilerplate</RootNamespace>
     <AssemblyName>UnitTestBoilerplate</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/UnitTestBoilerplate.csproj
+++ b/src/UnitTestBoilerplate.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Model\MethodArgumentDescriptor.cs" />
     <Compile Include="Model\MethodDescriptor.cs" />
     <Compile Include="Model\SelfTestDetectionTest.cs" />
+    <Compile Include="Model\TestFileContext.cs" />
     <Compile Include="Services\IBoilerplateSettings.cs" />
     <Compile Include="Services\MockBoilerplateSettings.cs" />
     <Compile Include="Services\FrameworkPickerService.cs" />

--- a/src/Utilities/SolutionUtilities.cs
+++ b/src/Utilities/SolutionUtilities.cs
@@ -23,9 +23,23 @@ namespace UnitTestBoilerplate.Utilities
 				.Select(i =>
 				{
 					var projectItem = i.Object as ProjectItem;
+					if (projectItem == null)
+					{
+						return null;
+					}
 					return new ProjectItemSummary(projectItem);
 				})
 				.ToList();
+		}
+
+		public static CodeFunction2 GetSelectedFunction(DTE2 dte)
+		{
+			TextSelection selectedText = dte.ActiveWindow.Selection as TextSelection;
+			if (selectedText == null)
+			{
+				return null;
+			}
+			return selectedText.ActivePoint.CodeElement[vsCMElement.vsCMElementFunction] as CodeFunction2;
 		}
 
 		public static IList<Project> GetProjects(DTE2 dte)

--- a/src/app.config
+++ b/src/app.config
@@ -1,55 +1,55 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>


### PR DESCRIPTION
Added TestFileContext class and modified test file generation methods to accept this context when there is a pre-existing unit test file. Pre-existing unit test are now preserved when re-generating test boilerplate for a given file. Test boilerplate can now be added on a method-by-method basis through the context menu brought up by right-clicking on a method name in the code window.